### PR TITLE
Fixed the ahead or behind info per branch

### DIFF
--- a/.profile
+++ b/.profile
@@ -19,7 +19,7 @@ git_dirty_check() {
 # export PS1='$(git_dirty_check) >'
 
 git_unpushed(){
-  brinfo=$(git branch -v | grep $(git_branch_name))
+  brinfo=$(git branch -v | grep "^\*.*"$(git_branch_name)".*$")
  
   if [[ $brinfo =~ ("[ahead "([[:digit:]]*)]) ]]
   then


### PR DESCRIPTION
It's now based on the current branch selected, and not some random branch